### PR TITLE
Register Personality config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/personality/core/Personality.java
+++ b/src/main/java/com/minecraftabnormals/personality/core/Personality.java
@@ -3,6 +3,7 @@ package com.minecraftabnormals.personality.core;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.DataProcessors;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedData;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedDataManager;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.personality.client.PersonalityClient;
 import com.minecraftabnormals.personality.common.network.MessageC2SCrawl;
 import com.minecraftabnormals.personality.common.network.MessageC2SSit;
@@ -49,6 +50,7 @@ public class Personality {
 
         MinecraftForge.EVENT_BUS.register(this);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, PersonalityConfig.CLIENT_SPEC);
+        DataUtil.registerConfigCondition(Personality.MOD_ID, PersonalityConfig.CLIENT);
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {

--- a/src/main/java/com/minecraftabnormals/personality/core/PersonalityConfig.java
+++ b/src/main/java/com/minecraftabnormals/personality/core/PersonalityConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.personality.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -26,7 +27,11 @@ public class PersonalityConfig {
     }
 
     public static class Keybindings {
+
+        @ConfigKey("toggle_crawl_enabled")
         public final ForgeConfigSpec.BooleanValue toggleCrawl;
+
+        @ConfigKey("toggle_sitting_enabled")
         public final ForgeConfigSpec.BooleanValue toggleSitting;
 
         public Keybindings(ForgeConfigSpec.Builder builder) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.